### PR TITLE
 Add support for glob to create only selected directories 

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -4,7 +4,7 @@
     "git add"
   ],
   "*.md": [
-    "prettier --prose-wrap always --write",
+    "prettier --no-config --prose-wrap always --write",
     "git add"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ import module from "package/lib/module";
 
 There are problems with this approach:
 
-* it is often encouraging people to import files authored in CJS format, which
+- it is often encouraging people to import files authored in CJS format, which
   if produced with tools like [`babel`](https://github.com/babel/babel) has i.e.
   interop helper functions deoptimizing imported file size when comparing to the
   same file authored in ESM format. Also `webpack` just bails out on CJS files
   when trying to optimize your application size with techniques such as
   tree-shaking & scope hoisting (a.k.a module concatenation).
-* it is exposing **internal directory structure** to the user. Why `lib` is in
+- it is exposing **internal directory structure** to the user. Why `lib` is in
   the requested path? If you ship both CJS & ESM directories to `npm` and if
   users would like to import appropriate file depending on the tool they are
   "forced" to remember this and switch between importing the same thing with
@@ -61,6 +61,7 @@ Options:
   --cjs-dir                                                     [default: "lib"]
   --esm-dir                                                      [default: "es"]
   --types-dir
+  --include                                        [default: "!(index).{js,ts}"]
   --cwd                                                           [default: "."]
   --input-dir                                                   [default: "src"]
 ```
@@ -76,6 +77,7 @@ Options:
   --help, -h     Show help                                             [boolean]
   --version, -v  Show version number                                   [boolean]
   --cwd                                                           [default: "."]
+  --include                                        [default: "!(index).{js,ts}"]
   --input-dir                                                   [default: "src"]
 ```
 

--- a/bin/cherry-pick.js
+++ b/bin/cherry-pick.js
@@ -4,8 +4,6 @@ const yargs = require('yargs')
 const chalk = require('chalk')
 const { default: cherryPick, clean } = require('..')
 
-const noop = () => {}
-
 const DONE_LABEL = chalk.green.inverse(' DONE ')
 
 yargs
@@ -19,6 +17,7 @@ yargs
 				.option('cjs-dir', { default: 'lib' })
 				.option('esm-dir', { default: 'es' })
 				.option('types-dir')
+				.option('include', { default: '!(index).{js,ts}' })
 				.option('cwd', { default: '.' }),
 		options =>
 			cherryPick(options).then(files =>
@@ -32,7 +31,11 @@ yargs
 	.command(
 		'clean [input-dir]',
 		'Cleanup generated directories',
-		yargs => yargs.default('input-dir', 'src').option('cwd', { default: '.' }),
+		yargs =>
+			yargs
+				.default('input-dir', 'src')
+				.option('cwd', { default: '.' })
+				.option('include', { default: '!(index).{js,ts}' }),
 		options =>
 			clean(options).then(files =>
 				console.log(

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,6 +19,7 @@ const withDefaults = (
 	additionalDefaults = {}
 ) => ({
 	inputDir: 'src',
+	include: '!(index).{js,ts}',
 	cwd: path.resolve(process.cwd(), cwd),
 	...additionalDefaults,
 	...options,
@@ -26,8 +27,8 @@ const withDefaults = (
 
 const noop = () => {}
 
-const findFiles = async ({ cwd, inputDir }) => {
-	const filePaths = await glob(path.join(inputDir, '!(index).{js,ts}'), {
+const findFiles = async ({ cwd, inputDir, include }) => {
+	const filePaths = await glob(path.join(inputDir, include), {
 		cwd,
 	})
 	return filePaths.map(filePath =>

--- a/package.json
+++ b/package.json
@@ -43,5 +43,11 @@
     "husky": "^0.14.3",
     "lint-staged": "^7.1.0",
     "prettier": "^1.12.1"
+  },
+  "prettier": {
+    "singleQuote": true,
+    "useTabs": true,
+    "semi": false,
+    "trailingComma": "es5"
   }
 }


### PR DESCRIPTION
This PR adds support for customizing the glob used to find the files to create and remove proxies for.

I want to use cherry-pick for a project where the source directory contains many files but where I only need a single proxy directory for one of them.

While putting this together I realized that when `cherry-pick` is being run in the prepublish hook and `cherry-pick clean` is being run in the postpublish hook and when `files` in `package.json` only specifies the desired proxy directories then creating additional ones is almost not an issue. Still, I find it nice to be able to specify only the ones I need. If nothing else it at least makes cherry-picks output a lot cleaner when it doesn't include many unwanted directories.

The PR also adds the Prettier config to `package.json` so that it can be picked up by editor plugins etc.