### PR TITLE
Using posix path in glob

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -29,7 +29,7 @@ const noop = () => {}
 
 const findFiles = async ({ cwd, inputDir }) => {
 	const filePaths = await glob(
-		path.join(inputDir, '!(index).{js,jsx,ts,tsx}'),
+		path.posix.join(inputDir, '!(index).{js,jsx,ts,tsx}'),
 		{ cwd }
 	)
 	return filePaths


### PR DESCRIPTION
Hello. My team had an issue with paths delimiters on windows. Tiny glob accepts only forward slashes (https://github.com/terkelg/tiny-glob#str). So, we came up with this fix.