### PR TITLE
Allow for nested files.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -29,12 +29,12 @@ const noop = () => {}
 
 const findFiles = async ({ cwd, inputDir }) => {
 	const filePaths = await glob(
-		path.join(inputDir, '!(index).{js,jsx,ts,tsx}'),
+		path.join(inputDir, '**/!(index).{js,jsx,ts,tsx}'),
 		{ cwd }
 	)
 	return filePaths
 		.filter(f => !f.endsWith('.d.ts'))
-		.map(filePath => path.basename(filePath).replace(/\.(js|ts)x?$/, ''))
+		.map(filePath => path.relative(inputDir, filePath).replace(/\.(js|ts)x?$/, ''))
 }
 
 const pkgCache = new WeakMap()
@@ -62,20 +62,22 @@ const fileProxy = async (options, file) => {
 	const { cwd, cjsDir, esmDir, typesDir } = options
 	const pkgName = await getPkgName(options)
 
+	const relativeDir = path.relative(file, '.');
+
 	const proxyPkg = {
 		name: `${pkgName}/${file}`,
 		private: true,
-		main: path.join('..', cjsDir, `${file}.js`),
-		module: path.join('..', esmDir, `${file}.js`),
+		main: path.join(relativeDir, cjsDir, `${file}.js`),
+		module: path.join(relativeDir, esmDir, `${file}.js`),
 	}
 
 	if (typeof typesDir === 'string') {
-		proxyPkg.types = path.join('..', typesDir, `${file}.d.ts`)
+		proxyPkg.types = path.join(relativeDir, typesDir, `${file}.d.ts`)
 	} else if (await isFile(path.join(cwd, `${file}.d.ts`))) {
-		proxyPkg.types = path.join('..', `${file}.d.ts`)
+		proxyPkg.types = path.join(relativeDir, `${file}.d.ts`)
 		// try the esm path in case types are located with each
 	} else if (await isFile(path.join(cwd, esmDir, `${file}.d.ts`))) {
-		proxyPkg.types = path.join('..', esmDir, `${file}.d.ts`)
+		proxyPkg.types = path.join(relativeDir, esmDir, `${file}.d.ts`)
 	}
 
 	return JSON.stringify(proxyPkg, null, 2) + '\n'
@@ -92,7 +94,7 @@ const cherryPick = async inputOptions => {
 	await Promise.all(
 		files.map(async file => {
 			const proxyDir = path.join(options.cwd, file)
-			await mkDir(proxyDir).catch(noop)
+			await mkDir(proxyDir, {recursive: true}).catch(noop)
 			await writeFile(
 				`${proxyDir}/package.json`,
 				await fileProxy(options, file)


### PR DESCRIPTION
I had the same issue as was reported in #8. The changes in this commit allow for packages with a nested structure more than one level deep. That is, this will allow users to create a package where you can, for example, do the following import:
```javascript
import bar from 'my-package/foo/bar';
```

Please let me know if there is anything you'd like to see changed in the code. Thanks!